### PR TITLE
fix: remove extra slash from movies endopint URL and update .gitignore [TASK-1]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 export const API_KEY = '8cac6dec66e09ab439c081b251304443'
 export const ENDPOINT = 'https://api.themoviedb.org/3'
-export const ENDPOINT_DISCOVER = ENDPOINT+'/discover/movie/?api_key='+API_KEY+'&sort_by=vote_count.desc'
-export const ENDPOINT_SEARCH = ENDPOINT+'/search/movie/?api_key='+API_KEY
+export const ENDPOINT_DISCOVER = ENDPOINT+'/discover/movie?api_key='+API_KEY+'&sort_by=vote_count.desc'
+export const ENDPOINT_SEARCH = ENDPOINT+'/search/movie?api_key='+API_KEY
 export const ENDPOINT_MOVIE = ENDPOINT+'/movie/507086?api_key='+API_KEY+'&append_to_response=videos'


### PR DESCRIPTION
Fix an error when fetching movies, as **the URL endpoint to _themoviedb_ API has an extra forward slash**, causing the movie  fetch return an error and not display movies in the app.